### PR TITLE
Fix logic to display "Next" button only after user is connected to Rinkeby

### DIFF
--- a/components/home/ChooseNetwork.js
+++ b/components/home/ChooseNetwork.js
@@ -62,14 +62,14 @@ export default function ChooseNetwork(props) {
               <i>connected to {getNetworkName(network)}</i>
             </Text>
           </HStack>
-        </>
-      ) : null}
           <Button
             className="transparent-btn"
             onClick={() => props.handleNext()}
           >
             Next »
           </Button>
+        </>
+      ) : null}
     </VStack>
-  );
+  )
 }

--- a/components/home/FactoryWrapper.js
+++ b/components/home/FactoryWrapper.js
@@ -12,7 +12,7 @@ import StepProgressBar from "./StepProgressBar";
 export default function FactoryWrapper() {
   const [visible, setVisible] = useState(0);
   const [details, setDetails] = useState({
-    network: 999,
+    network: 4,
     identity: {
       daoName: null,
       symbol: null,


### PR DESCRIPTION
FactoryWrapper.js
- Update default network to 4 (aka Rinkeby)

ChooseNetwork.js
- Hide "Next" button when user is not connected to Rinkeby
- Display "Next" button only after user is connected to Rinkeby

Before fix 
<img width="694" alt="Screenshot 2022-02-01 213600" src="https://user-images.githubusercontent.com/5264156/152085588-59efd8f2-1b0d-4f1e-ab55-a58f1c3f1f99.png">

After fix
<img width="695" alt="Screenshot 2022-02-01 213617" src="https://user-images.githubusercontent.com/5264156/152085598-2523a0b3-fea0-449d-a3b3-8a47b3469342.png">
<img width="692" alt="Screenshot 2022-02-01 215028" src="https://user-images.githubusercontent.com/5264156/152085816-347742f5-c401-427a-a166-e3b6dcd5cd1e.png">

